### PR TITLE
add docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist
 .cache
 /bin
 .target
+overrideDockerImageName.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,85 @@
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-name := "GitRawFileProxy"
+lazy val root = (project in file("."))
+  .enablePlugins(PlayScala, sbtdocker.DockerPlugin, DockerComposePlugin)
+  .settings(rootSettings: _*)
+  .settings(herokuSettings: _*)
+  .settings(dockerSettings: _*)
 
-version := "1.0-SNAPSHOT"
+lazy val rootSettings = Seq(
+  organization := "net.kaliber",
+  name := "GitHubRawFileProxy",
 
-scalaVersion := "2.11.8"
-
-libraryDependencies += ws
-
-herokuAppName in Compile := "github-file-proxy-production"
-
-herokuProcessTypes in Compile := Map(
-  "web" -> "target/universal/stage/bin/githubrawfileproxy -Dhttp.port=$PORT -Dallowed.accessTokens=$ALLOWED_ACCESSTOKENS"
+  scalaVersion := "2.11.8",
+  libraryDependencies += ws
 )
+
+lazy val herokuSettings = Seq(
+  herokuAppName in Compile := "github-file-proxy-production",
+
+  herokuProcessTypes in Compile := Map(
+    "web" -> "target/universal/stage/bin/githubrawfileproxy -Dhttp.port=$PORT -Dallowed.accessTokens=$ALLOWED_ACCESSTOKENS"
+  )
+)
+
+lazy val dockerSettings = Seq(
+  mainClass in assembly := Some("play.core.server.ProdServerStart"),
+
+  fullClasspath in assembly += Attributed.blank(PlayKeys.playPackageAssets.value),
+
+  assemblyJarName in assembly := s"${name.value}-${version.value}.jar",
+
+  assemblyMergeStrategy in assembly := {
+    case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
+    case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
+    case x =>
+      val oldStrategy = (assemblyMergeStrategy in assembly).value
+      oldStrategy(x)
+  },
+
+  //assembly. It brings in signpost-commonshttp4, which leads to commons-logging. This conflicts with jcl-over-slf4j, which re-implements the logging API
+  libraryDependencies ~= { _ map {
+    case m if m.organization == "com.typesafe.play" =>
+      m.exclude("commons-logging", "commons-logging").
+        exclude("com.typesafe.play", "sbt-link")
+    case m => m
+  }},
+
+  dockerfile in docker := {
+    // The assembly task generates a fat JAR file
+    val artifact = assembly.value
+    val artifactTargetPath = s"/app/${artifact.name}"
+
+    //You can start this container with
+    // docker run --name resource-api-test -p 9000:9000 -v {configDir}:/configs -v {logdir}:/logs -e JAVA_OPTS='-Dconfig.file=/configs/{environment}.conf' {dockerImageName}
+
+    new Dockerfile {
+      from("java")
+      maintainer("Pointlogic")
+      add(artifact, artifactTargetPath)
+      volume("/configs", "/logs")
+      entryPointShell("exec", "java", "$JAVA_OPTS", "-jar", artifactTargetPath, "$@")
+    }
+  },
+
+  // exposing the play ports
+  dockerExposedPorts in docker := Seq(9000, 9443),
+
+  buildOptions in docker := BuildOptions(cache = false),
+
+  imageNames in docker := dockerImageNames.value,
+
+  dockerImageCreationTask := docker.value
+)
+
+lazy val overrideDockerImageNames = settingKey[Option[Seq[ImageName]]]("get the docker image name")
+overrideDockerImageNames := None
+
+lazy val dockerImageNames = taskKey[Seq[ImageName]]("get the docker image name")
+dockerImageNames := {
+  val fallback = s"${organization.value}/${name.value}-${version.value}:latest"
+
+  overrideDockerImageNames.value match {
+    case Some(names) => names
+    case _ => Seq(ImageName(fallback))
+  }
+}

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")

--- a/project/docker-compose.sbt
+++ b/project/docker-compose.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.22")

--- a/project/docker.sbt
+++ b/project/docker.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.4.1")

--- a/project/heroku.sbt
+++ b/project/heroku.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.heroku" % "sbt-heroku" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,4 @@
 // Comment to get more information during initialization
 logLevel := Level.Warn
 
-// The Play plugin
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.14")
-
-resolvers += Resolver.url("heroku-sbt-plugin-releases",
-  url("http://dl.bintray.com/heroku/sbt-plugins/"))(Resolver.ivyStylePatterns)
-
-addSbtPlugin("com.heroku" % "sbt-heroku" % "1.0.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "1.0-SNAPSHOT"


### PR DESCRIPTION
Docker containers are widely used for hosting. This add support to register a docker image so that you can host this anywhere besides Heroku.